### PR TITLE
fix: `linseq` and `logseq` only working for integers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.8.3
+
+## Common
+
+- Fix `linseq` and `logseq` only working for integers
+
 # 2.8.2
 
 ## Common

--- a/cace/__version__.py
+++ b/cace/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '2.8.2'
+__version__ = '2.8.3'
 
 if __name__ == '__main__':
     print(__version__, end='')

--- a/cace/parameter/parameter.py
+++ b/cace/parameter/parameter.py
@@ -150,24 +150,24 @@ class Condition:
             if self.spec['step'] == 'linear':
                 stepsize = 1
                 if 'stepsize' in self.spec:
-                    stepsize = self.spec['stepsize']
+                    stepsize = float(self.spec['stepsize'])
 
                 yield from linseq(
-                    int(self.spec['minimum']),
-                    int(self.spec['maximum']),
-                    int(stepsize),
+                    float(self.spec['minimum']),
+                    float(self.spec['maximum']),
+                    stepsize,
                 )
 
             # Logarithmic step
             elif self.spec['step'] == 'logarithmic':
                 stepsize = 2
                 if 'stepsize' in self.spec:
-                    stepsize = self.spec['stepsize']
+                    stepsize = float(self.spec['stepsize'])
 
                 yield from logseq(
-                    int(self.spec['minimum']),
-                    int(self.spec['maximum']),
-                    int(stepsize),
+                    float(self.spec['minimum']),
+                    float(self.spec['maximum']),
+                    stepsize,
                 )
 
             else:


### PR DESCRIPTION
- Fix `linseq` and `logseq` only working for integers