### PR TITLE
Updating Klayout DRC to work with new IHP run_drc.py

### DIFF
--- a/cace/parameter/parameter_klayout_drc.py
+++ b/cace/parameter/parameter_klayout_drc.py
@@ -15,6 +15,7 @@
 import os
 import re
 import sys
+import glob
 
 from ..common.common import run_subprocess, get_pdk_root, get_layout_path
 from .parameter import Parameter, ResultType, Argument, Result
@@ -162,8 +163,10 @@ class ParameterKLayoutDRC(Parameter):
 
             # The report is placed in a .lyrdb file
             #  - The name of this file depends on which rulesets were checked...
-            #  - Only one report remains after merging
-            report_file_path = self.param_dir + '/' + [f for f in os.listdir(self.param_dir) if len(f) >= 6 and  f[-6:] == ".lyrdb"][0]
+            #  - Only one report should remain after merging by run_drc.py
+            report_files = glob.glob(f'{self.param_dir}/*.lyrdb')
+            if len(report_files) > 0:
+                report_file_path = report_files[0]
 
         else:
             returncode = self.run_subprocess(


### PR DESCRIPTION
This updates the Klayout DRC for IHP PDK to use the new run_drc.py script.

The run_drc.py script doesn't have an argument to override the final report name so the script is updated to figure out the right name of the report file.  This could also have been done with a glob, but I didn't want to include another library for this.