### PR TITLE
Add collapsible sections to markdown summary

### DIFF
--- a/cace/common/cace_write.py
+++ b/cace/common/cace_write.py
@@ -242,6 +242,10 @@ def markdown_summary(datasheet, runtime_options, results, result_types):
 
     result += f'**netlist source**: {runtime_options["netlist_source"]}\n\n'
 
+    # Add collapsible section for parameters
+    result += '<details open>\n'
+    result += '<summary>📊 Parameter Results</summary>\n\n'
+
     # Print the table headings
     result += ''.join(
         [
@@ -399,7 +403,7 @@ def markdown_summary(datasheet, runtime_options, results, result_types):
                 ]
             )
 
-    result += '\n'
+    result += '\n</details>\n\n'
     return result
 
 


### PR DESCRIPTION
Description
This PR implements collapsible sections for the markdown summary as requested in #14.

 Changes
- Wrapped the parameter results table in HTML `<details>` tags
- Used the `open` attribute so the section is expanded by default for better UX
- Added an emoji (📊) to the summary heading for visual clarity

Implementation Details
Modified `cace/common/cace_write.py` in the `markdown_summary()` function
Added `<details open>` tag before the table
Added `<summary>📊 Parameter Results</summary>` as the collapsible header
Closed with `</details>` tag after the table


It may not render correctly in very basic/old markdown parsers, but this is an acceptable tradeoff for the improved readability.

Testing
No syntax errors in the modified file
 CACE CLI runs successfully with the changes
 Generated markdown includes proper `<details>` structure

Fixes #14